### PR TITLE
Adding indentation configuration

### DIFF
--- a/after/ftplugin/yaml.vim
+++ b/after/ftplugin/yaml.vim
@@ -1,6 +1,7 @@
 " Vim indent file
 " Language: Yaml
-" Author: Ian Young
-" URL: https://github.com/avakhov/vim-yaml
+" Author: Henrique Barcelos
+" Date: 2014-10-08
+" URL: https://github.com/hjpbarcelos
 setlocal autoindent sw=2 ts=2 expandtab
 " vim:set sw=2:


### PR DESCRIPTION
Adding indentation configuration in order to follow some YAML standards:
- Indenting by spaces
- 2-spaces indentation

Vim configuration:

``` vim
setlocal autoindent sw=2 ts=2 expandtab
```

It's not much, but is everything I need for now.
