### PR TITLE
anchor keys to start of line & allow all non-whitespace

### DIFF
--- a/after/syntax/yaml.vim
+++ b/after/syntax/yaml.vim
@@ -38,7 +38,7 @@ syn keyword yamlConstant NULL Null null NONE None none NIL Nil nil
 syn keyword yamlConstant TRUE True true YES Yes yes ON On on
 syn keyword yamlConstant FALSE False false NO No no OFF Off off
 
-syn match  yamlKey	"\w\+\ze\s*:"
+syn match  yamlKey	"^\s*\zs\S\+\ze\s*:"
 syn match  yamlAnchor	"&\S\+"
 syn match  yamlAlias	"*\S\+"
 


### PR DESCRIPTION
This fixes two bugs

1. Highlighting keys with non-word characters in them e.g. `a-b:` only `b` gets highlighted
2. Highlighting colons in text as keys e.g. `a: foo.bar:baz` `bar` is highlighted