### PR TITLE
Exclude double-quotes from key names

### DIFF
--- a/after/syntax/yaml.vim
+++ b/after/syntax/yaml.vim
@@ -36,8 +36,8 @@ syn keyword yamlConstant NULL Null null NONE None none NIL Nil nil
 syn keyword yamlConstant TRUE True true YES Yes yes ON On on
 syn keyword yamlConstant FALSE False false NO No no OFF Off off
 
-syn match  yamlKey	"^\s*\zs\S\+\ze\s*:"
-syn match  yamlKey	"^\s*-\s*\zs\S\+\ze\s*:"
+syn match  yamlKey	"^\s*\zs[^ \t\"]\+\ze\s*:"
+syn match  yamlKey	"^\s*-\s*\zs[^ \t\"]\+\ze\s*:"
 syn match  yamlAnchor	"&\S\+"
 syn match  yamlAlias	"*\S\+"
 


### PR DESCRIPTION
This prevents accidentally identifying `"foo` as a key name in the following YAML:

    ---
    - "foo:bar"

Fixes stephpy/vim-yaml#6