### PR TITLE
Protect against apostrophes matching string start/end

### DIFF
--- a/after/syntax/yaml.vim
+++ b/after/syntax/yaml.vim
@@ -24,7 +24,7 @@ syn match yamlBlock "[\[\]\{\}\|\>]"
 syn region yamlComment	start="\#" end="$"
 syn match yamlIndicator	"#YAML:\S\+"
 
-syn region yamlString	start="'" end="'" skip="\\'"
+syn region yamlString	start="\%(^\| \)\zs'" end="'\ze\%( \|$\)" skip="\\'"
 syn region yamlString	start='"' end='"' skip='\\"' contains=yamlEscape
 syn match  yamlEscape	+\\[abfnrtv'"\\]+ contained
 syn match  yamlEscape	"\\\o\o\=\o\=" contained


### PR DESCRIPTION
Addresses issue #10 - single quote in values break highlighting.

This causes the opening quote for a string only to be recognised when
it's preceded by a space of by the start of line, and the closing quote
to only be recognised when succeeded by a space or by the end of line.

Now you can use apostrophes in yaml files :)