### PR TITLE
Fix singlequote start

### DIFF
--- a/after/syntax/yaml.vim
+++ b/after/syntax/yaml.vim
@@ -25,7 +25,7 @@ syn match yamlBlock "[>|]\d\?[+-]"
 syn region yamlComment	start="\#" end="$"
 syn match yamlIndicator	"#YAML:\S\+"
 
-syn region yamlString	start="\(^\|\s\|\[\|\,\|\-\)'" end="'" skip="\\'"
+syn region yamlString	start="\(^\|\s\|\[\|\,\|\-\)\@<='" end="'" skip="\\'"
 syn region yamlString	start='"' end='"' skip='\\"' contains=yamlEscape
 syn region yamlString	matchgroup=yamlBlock start=/[>|]\s*\n\+\z(\s\+\)\S/rs=s+1 skip=/^\%(\z1\S\|^$\)/ end=/^\z1\@!.*/me=s-1
 syn region yamlString	matchgroup=yamlBlock start=/[>|]\(\d\|[+-]\)\s*\n\+\z(\s\+\)\S/rs=s+2 skip=/^\%(\z1\S\|^$\)/ end=/^\z1\@!.*/me=s-1


### PR DESCRIPTION
This should solve problem introduced in #12. It looks for single quote prefix with lookbehind, so it's not highlighted.

Before:
![vim-syntax-before](https://user-images.githubusercontent.com/8525083/50731291-244c7080-1161-11e9-8629-43dd0da26509.png)

After:
![vim-syntax-after](https://user-images.githubusercontent.com/8525083/50731293-29112480-1161-11e9-82d4-d2d8a0e81699.png)

