### PR TITLE
Adds option to limit spell checking

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,9 @@ Vim Yaml
 Syntax file from [http://www.vim.org/scripts/script.php?script_id=739](http://www.vim.org/scripts/script.php?script_id=739)
 
 Yaml files in vim 7.4 are really slow, due to core yaml syntax. This syntax is simpler/faster.
+
+`g:yaml_limit_spell`
+-------------------
+
+Set to `1` to limit spell checking (if spelling is enabled) to Yaml comments and
+strings.

--- a/after/syntax/yaml.vim
+++ b/after/syntax/yaml.vim
@@ -19,17 +19,25 @@ if version < 600
 endif
 syntax clear
 
+if exists('g:yaml_limit_spell') && g:yaml_limit_spell
+ syn cluster yamlSpelling contains=@Spell
+else
+ " dummy directive to just have yamlSpelling defined, without any group
+ syn cluster yamlSpelling remove=whatever
+endif
+
+
 syn match yamlInline "[\[\]\{\}]"
 syn match yamlBlock "[>|]\d\?[+-]"
 
-syn region yamlComment	start="\#" end="$"
+syn region yamlComment	start="\#" end="$" contains=@yamlSpelling
 syn match yamlIndicator	"#YAML:\S\+"
 
-syn region yamlString	start="\(^\|\s\|\[\|\,\|\-\)\@<='" end="'" skip="\\'"
-syn region yamlString	start='"' end='"' skip='\\"' contains=yamlEscape
-syn region yamlString	matchgroup=yamlBlock start=/[>|]\s*\n\+\z(\s\+\)\S/rs=s+1 skip=/^\%(\z1\S\|^$\)/ end=/^\z1\@!.*/me=s-1
-syn region yamlString	matchgroup=yamlBlock start=/[>|]\(\d\|[+-]\)\s*\n\+\z(\s\+\)\S/rs=s+2 skip=/^\%(\z1\S\|^$\)/ end=/^\z1\@!.*/me=s-1
-syn region yamlString	matchgroup=yamlBlock start=/[>|]\d\(\d\|[+-]\)\s*\n\+\z(\s\+\)\S/rs=s+3 skip=/^\%(\z1\S\|^$\)/ end=/^\z1\@!.*/me=s-1
+syn region yamlString	start="\(^\|\s\|\[\|\,\|\-\)\@<='" end="'" skip="\\'" contains=@yamlSpelling
+syn region yamlString	start='"' end='"' skip='\\"' contains=yamlEscape contains=@yamlSpelling
+syn region yamlString	matchgroup=yamlBlock start=/[>|]\s*\n\+\z(\s\+\)\S/rs=s+1 skip=/^\%(\z1\S\|^$\)/ end=/^\z1\@!.*/me=s-1 contains=@yamlSpelling
+syn region yamlString	matchgroup=yamlBlock start=/[>|]\(\d\|[+-]\)\s*\n\+\z(\s\+\)\S/rs=s+2 skip=/^\%(\z1\S\|^$\)/ end=/^\z1\@!.*/me=s-1 contains=@yamlSpelling
+syn region yamlString	matchgroup=yamlBlock start=/[>|]\d\(\d\|[+-]\)\s*\n\+\z(\s\+\)\S/rs=s+3 skip=/^\%(\z1\S\|^$\)/ end=/^\z1\@!.*/me=s-1 contains=@yamlSpelling
 syn match  yamlEscape	+\\[abfnrtv'"\\]+ contained
 syn match  yamlEscape	"\\\o\o\=\o\=" contained
 syn match  yamlEscape	"\\x\x\+" contained


### PR DESCRIPTION
As it is now, with `set spell`, a yaml file can get full of errors because e.g. yaml keys contain spelling errors. For instance:

![Screenshot_20200405_175513](https://user-images.githubusercontent.com/11805218/78503430-07cd2880-7756-11ea-9f93-3403bc4f02af.png)

This PR adds an option `g:yaml_limit_spell` to limit spell checking only to those things that it makes sense, i.e. comments and strings. With this option enabled, the above example looks like:

![Screenshot_20200405_175600](https://user-images.githubusercontent.com/11805218/78503448-27645100-7756-11ea-83f1-adc8b83aaea1.png)
