### PR TITLE
Add dashes to iskeyword

### DIFF
--- a/after/ftplugin/yaml.vim
+++ b/after/ftplugin/yaml.vim
@@ -4,4 +4,5 @@
 " Date: 2014-10-08
 " URL: https://github.com/hjpbarcelos
 setlocal autoindent sw=2 ts=2 expandtab
+setlocal iskeyword+=-
 " vim:set sw=2:


### PR DESCRIPTION
I have found that it is common in yaml files (particularly in kubernetes) to use dashes as delimiters within the name of resources and other keys.  In order to get vim's auto-completion to work as expected, I've added the dash to `iskeyword` to teach vim these are all one word.  If you don't find this to be a useful change, I can just make it locally, but I thought others may find this useful as well. 