### PR TITLE
fix(after syntax): use `hi def`

### DIFF
--- a/after/syntax/yaml.vim
+++ b/after/syntax/yaml.vim
@@ -55,15 +55,15 @@ syn match  yamlAlias	"*\S\+"
 
 " Setup the highlighting links
 
-hi link yamlConstant Keyword
-hi link yamlIndicator PreCondit
-hi link yamlAnchor	Function
-hi link yamlAlias	Function
-hi link yamlKey		Identifier
-hi link yamlType	Type
+hi def link yamlConstant Keyword
+hi def link yamlIndicator PreCondit
+hi def link yamlAnchor	Function
+hi def link yamlAlias	Function
+hi def link yamlKey		Identifier
+hi def link yamlType	Type
 
-hi link yamlComment	Comment
-hi link yamlInline	Operator
-hi link yamlBlock	Operator
-hi link yamlString	String
-hi link yamlEscape	Special
+hi def link yamlComment	Comment
+hi def link yamlInline	Operator
+hi def link yamlBlock	Operator
+hi def link yamlString	String
+hi def link yamlEscape	Special


### PR DESCRIPTION
This is to allow colorschemes to override these highlights without having to `:hi clear`. `:hi clear`ing can be undesirable in certain situations (since it clears the highlights applied by other plugins), and an alternative to forcing this is to specify these highlights as `def` so that if a definition for a group is already in place it won't override what is there.